### PR TITLE
Add basic example with separate 'bench' configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ jdk:
 env:
   - TEST_DIR=basic
     TASKS="test:compile"
+  - TEST_DIR=basic-with-separate-config
+    TASKS="bench:compile"
 script: cd $TEST_DIR && sbt $TRAVIS_SCALA_VERSION_ARG $TASKS
 branches:
   only:

--- a/basic-with-separate-config/build.sbt
+++ b/basic-with-separate-config/build.sbt
@@ -1,0 +1,30 @@
+lazy val Benchmark = config("bench") extend Test
+
+/**  This allows running ScalaMeter benchmarks in separate sbt configuration.
+  *  It means, that when you want run your benchmarks you should type `bench:test` in sbt console.
+  */
+lazy val basic = Project(
+  "basic-with-separate-config",
+  file("."),
+  settings = Defaults.coreDefaultSettings ++ Seq(
+    name := "scalameter-examples",
+    organization := "com.storm-enroute",
+    scalaVersion := "2.11.1",
+    scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xlint"),
+    publishArtifact := false,
+    libraryDependencies ++= Seq(
+      "com.storm-enroute" %% "scalameter" % version.value % "bench" // ScalaMeter version is set in version.sbt
+    ),
+    resolvers ++= Seq(
+      "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
+      "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases"
+    ),
+    testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework"),
+    parallelExecution in Benchmark := false,
+    logBuffered := false
+  )
+) configs (
+  Benchmark
+) settings(
+  inConfig(Benchmark)(Defaults.testSettings): _*
+)

--- a/basic-with-separate-config/project/build.properties
+++ b/basic-with-separate-config/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/basic-with-separate-config/src/bench/scala/org/scalameter/examples/RangeBenchmark.scala
+++ b/basic-with-separate-config/src/bench/scala/org/scalameter/examples/RangeBenchmark.scala
@@ -1,0 +1,19 @@
+package org.scalameter.examples
+
+import org.scalameter.api._
+
+object RangeBenchmark extends PerformanceTest.Quickbenchmark {
+  val sizes = Gen.range("size")(300000, 1500000, 300000)
+
+  val ranges = for {
+    size <- sizes
+  } yield 0 until size
+
+  performance of "Range" in {
+    measure method "map" in {
+      using(ranges) in {
+        r => r.map(_ + 1)
+      }
+    }
+  }
+}

--- a/basic-with-separate-config/version.sbt
+++ b/basic-with-separate-config/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.7-SNAPSHOT"


### PR DESCRIPTION
Just another basic example, which shows how to run benchmarks in separate configuration typing `bench:test`
