### PR TITLE
Add more invocation count measurers examples

### DIFF
--- a/invocation-count-measurers/src/bench/scala/org/scalameter/examples/BoxingCountBenchmark.scala
+++ b/invocation-count-measurers/src/bench/scala/org/scalameter/examples/BoxingCountBenchmark.scala
@@ -3,23 +3,23 @@ package org.scalameter.examples
 import org.scalameter.api._
 
 
-class RangeBenchmark extends PerformanceTest.Microbenchmark {
+class BoxingCountBenchmark extends PerformanceTest.Microbenchmark {
   val sizes = Gen.range("size")(300000, 1500000, 300000)
 
-  val ranges = for {
+  val lists = for {
     size <- sizes
-  } yield 0 until size
+  } yield (0 until size).toList
 
   performance of "Range" in {
-    measure method "boxing" in {
-      using(ranges) in {
+    measure method "map" in {
+      using(lists) in {
         r => r.map(_ + 1)
       }
     }
   }
 
   // we want to count (auto)boxing of int values
-  override def measurer: Measurer = Measurer.BoxingCount(classOf[Int])
+  override lazy val measurer: Measurer = Measurer.BoxingCount(classOf[Int])
 
   // we want one JVM instance since this measurer is deterministic
   override def defaultConfig: Context = Context(exec.independentSamples -> 1)

--- a/invocation-count-measurers/src/bench/scala/org/scalameter/examples/DescendantsAllocationsBenchmark.scala
+++ b/invocation-count-measurers/src/bench/scala/org/scalameter/examples/DescendantsAllocationsBenchmark.scala
@@ -1,0 +1,34 @@
+package org.scalameter.examples
+
+import org.scalameter.api._
+import org.scalameter.execution.invocation.InvocationCountMatcher
+import org.scalameter.execution.invocation.InvocationCountMatcher.{MethodMatcher, ClassMatcher}
+import scala.util.Random
+
+
+class DescendantsAllocationsBenchmark extends PerformanceTest.Microbenchmark {
+  val sizes = Gen.range("size")(300000, 1500000, 300000)
+
+  val lists = for {
+    size <- sizes
+  } yield (0 until size).toList
+
+  performance of "List" in {
+    measure method "map" in {
+      using(lists) in {
+        // since we count both Left and Right, all list elements should be counted
+        l => l.map(e => if (Random.nextBoolean()) Left(e) else Right(e))
+      }
+    }
+  }
+
+  // we want to count allocations of `Option` method invocations
+  override lazy val measurer: Measurer =
+    Measurer.MethodInvocationCount(InvocationCountMatcher(
+      ClassMatcher.Descendants(classOf[Either[_, _]], direct = true, withSelf = false),
+      MethodMatcher.MethodName("<init>")
+    ))
+
+  // we want one JVM instance since this measurer is deterministic
+  override def defaultConfig: Context = Context(exec.independentSamples -> 1)
+}

--- a/invocation-count-measurers/src/bench/scala/org/scalameter/examples/FullMethodInvocationCountBenchmark.scala
+++ b/invocation-count-measurers/src/bench/scala/org/scalameter/examples/FullMethodInvocationCountBenchmark.scala
@@ -1,0 +1,37 @@
+package org.scalameter.examples
+
+import org.scalameter.api._
+import org.scalameter.execution.invocation.InvocationCountMatcher
+import org.scalameter.picklers.noPickler._
+
+
+class FullMethodInvocationCountBenchmark extends PerformanceTest.Microbenchmark {
+  val sizes = Gen.range("size")(1000, 10000, 1000)
+  val methods = Gen.enumeration("method")(
+    (bi: BigInt) => bi.toString(), (bi: BigInt) => bi.toString(10), (bi: BigInt) => bi.toByteArray
+  )
+
+  val ranges = for {
+    size <- sizes
+  } yield 0 until size
+
+  val combined = Gen.tupled(ranges, methods)
+
+  performance of "Range" in {
+    measure method "foreach" in {
+      using(combined) in {
+        // count should equal range size for no-arg toString method, and 0 for rest methods
+        case (r, m) => r.foreach(e => m(BigInt(e)))
+      }
+    }
+  }
+
+  // we want to count only no-arg toString method
+  override lazy val measurer: Measurer =
+    Measurer.MethodInvocationCount(InvocationCountMatcher.forClass(
+      classOf[BigInt], classOf[BigInt].getMethod("toString")
+    ))
+
+  // we want one JVM instance since this measurer is deterministic
+  override def defaultConfig: Context = Context(exec.independentSamples -> 1)
+}

--- a/invocation-count-measurers/src/bench/scala/org/scalameter/examples/RegexMethodInvocationCountBenchmark.scala
+++ b/invocation-count-measurers/src/bench/scala/org/scalameter/examples/RegexMethodInvocationCountBenchmark.scala
@@ -1,0 +1,35 @@
+package org.scalameter.examples
+
+import org.scalameter.api._
+import org.scalameter.execution.invocation.InvocationCountMatcher
+import org.scalameter.picklers.noPickler._
+
+
+class RegexMethodInvocationCountBenchmark extends PerformanceTest.Microbenchmark {
+  val sizes = Gen.range("size")(1000, 10000, 1000)
+  val methods = Gen.enumeration("method")(
+    (bi: BigInt) => bi.toString(), (bi: BigInt) => bi.toString(10), (bi: BigInt) => bi.toByteArray
+  )
+
+  val ranges = for {
+    size <- sizes
+  } yield 0 until size
+
+  val combined = Gen.tupled(ranges, methods)
+
+  performance of "Range" in {
+    measure method "foreach" in {
+      using(combined) in {
+        // count should equal range size for all methods
+        case (r, m) => r.foreach(e => m(BigInt(e)))
+      }
+    }
+  }
+
+  // we want to count all methods that begins with "to"
+  override lazy val measurer: Measurer =
+    Measurer.MethodInvocationCount(InvocationCountMatcher.forRegex("scala.math.BigInt".r, "^to\\w+".r))
+
+  // we want one JVM instance since this measurer is deterministic
+  override def defaultConfig: Context = Context(exec.independentSamples -> 1)
+}

--- a/invocation-count-measurers/src/bench/scala/org/scalameter/examples/SimpleAllocationsBenchmark.scala
+++ b/invocation-count-measurers/src/bench/scala/org/scalameter/examples/SimpleAllocationsBenchmark.scala
@@ -3,29 +3,28 @@ package org.scalameter.examples
 import org.scalameter.api._
 import org.scalameter.execution.invocation.InvocationCountMatcher
 import org.scalameter.execution.invocation.InvocationCountMatcher.{MethodMatcher, ClassMatcher}
+import scala.util.Random
 
 
-object ListBenchmark extends PerformanceTest.OfflineRegressionReport {
+class SimpleAllocationsBenchmark extends PerformanceTest.Microbenchmark {
   val sizes = Gen.range("size")(300000, 1500000, 300000)
 
   val lists = for {
     size <- sizes
   } yield (0 until size).toList
 
-  performance of "Option" in {
-    measure method "allocations" in {
+  performance of "List" in {
+    measure method "map" in {
       using(lists) in {
-        l => l.map(Some(_))
+        // approximately half of elements should be counted
+        l => l.map(e => if (Random.nextBoolean()) Left(e) else Right(e))
       }
     }
   }
 
   // we want to count allocations of `Option` method invocations
-  override def measurer: Measurer =
-    Measurer.MethodInvocationCount(InvocationCountMatcher(
-      ClassMatcher.Descendants(classOf[Option[_]], direct = true, withSelf = false),
-      MethodMatcher.MethodName("<init>")
-    ))
+  override lazy val measurer: Measurer =
+    Measurer.MethodInvocationCount(InvocationCountMatcher.allocations(classOf[Right[_, _]]))
 
   // we want one JVM instance since this measurer is deterministic
   override def defaultConfig: Context = Context(exec.independentSamples -> 1)

--- a/invocation-count-measurers/src/bench/scala/org/scalameter/examples/SimpleMethodInvocationCountBenchmark.scala
+++ b/invocation-count-measurers/src/bench/scala/org/scalameter/examples/SimpleMethodInvocationCountBenchmark.scala
@@ -1,0 +1,35 @@
+package org.scalameter.examples
+
+import org.scalameter.api._
+import org.scalameter.execution.invocation.InvocationCountMatcher
+import org.scalameter.picklers.noPickler._
+
+
+class SimpleMethodInvocationCountBenchmark extends PerformanceTest.Microbenchmark {
+  val sizes = Gen.range("size")(1000, 10000, 1000)
+  val methods = Gen.enumeration("method")(
+    (bi: BigInt) => bi.toString(), (bi: BigInt) => bi.toString(10), (bi: BigInt) => bi.toByteArray
+  )
+
+  val ranges = for {
+    size <- sizes
+  } yield 0 until size
+
+  val combined = Gen.tupled(ranges, methods)
+
+  performance of "Range" in {
+    measure method "foreach" in {
+      using(combined) in {
+        // count should equal range size for both toString methods, and 0 for toByteArray method
+        case (r, m) => r.foreach(e => m(BigInt(e)))
+      }
+    }
+  }
+
+  // we want to count all methods that are toString methods
+  override lazy val measurer: Measurer =
+    Measurer.MethodInvocationCount(InvocationCountMatcher.forName("scala.math.BigInt", "toString"))
+
+  // we want one JVM instance since this measurer is deterministic
+  override def defaultConfig: Context = Context(exec.independentSamples -> 1)
+}


### PR DESCRIPTION
I've added next examples.

Btw, just to be sure (since my question could be missed in previous `scalameter-examples` PR):
What do you think about adding something like:

```
case object Allocation extends MethodMatcher {
      def matches(methodName: String, methodDescriptor: String): Boolean = methodName == "<init>"
}
```

as a simplification for the user, who would like to count allocations with e.g. all descendants (as it's shown in the `DescendantsAllocationsBenchmark`)
